### PR TITLE
remove init function

### DIFF
--- a/susepubliccloud/provider.go
+++ b/susepubliccloud/provider.go
@@ -20,9 +20,6 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func init() {
-}
-
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	return nil, nil
 }


### PR DESCRIPTION
I don't have tested this but Unless i'm not seeing why ` init` function should be used empty, I think it should simply removed 